### PR TITLE
Add integration with MySQL Charm

### DIFF
--- a/bin/mysql-simple-env.ecl
+++ b/bin/mysql-simple-env.ecl
@@ -1,0 +1,168 @@
+IMPORT mysql;
+
+/*
+ This example illustrates various calls to embdded MySQL code
+ */
+
+// This is the record structure in ECL that will correspond to the rows in the MySQL dataset
+// Note that the default values specified in the fields will be used when a NULL value is being
+// returned from MySQL
+
+childrec := RECORD
+   string name,
+   integer4 value { default(99999) },
+   boolean boolval { default(true) },
+   real8 r8 {default(99.99)},
+   real4 r4 {default(999.99)},
+   DATA d {default (D'999999')},
+   DECIMAL10_2 ddd {default(9.99)},
+   UTF8 u1 {default(U'9999 ß')},
+   UNICODE8 u2 {default(U'9999 ßßßß')}
+END;
+
+// Some data we will use to initialize the MySQL table
+
+init := DATASET([{'name1', 1, true, 1.2, 3.4, D'aa55aa55', 1234567.89, U'Straße', U'Straße'},
+                 {'name2', 2, false, 5.6, 7.8, D'00', -1234567.89, U'là', U'là'}], childrec);
+
+// Set up the MySQL database
+// Enable remote access to your MySQL DB Server to use its DNS name or IP, else use localhost or 10.172.37.113
+// If port argument is omitted, it defaults to 3306
+
+dbUser := GETENV('MYSQLDB_USER');
+OUTPUT(dbUser);
+dbPassword := GETENV('MYSQLDB_PASSWORD');
+OUTPUT(dbPassword);
+dbDatabase := GETENV('MYSQLDB_DATABASE');
+OUTPUT(dbDatabase);
+dbServer := GETENV('MYSQLDB_HOST');
+OUTPUT(dbServer);
+dbPort := '3306';
+
+//EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+
+drop() := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  DROP TABLE IF EXISTS tbl1;
+ENDEMBED;
+
+create() := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  CREATE TABLE tbl1 ( name VARCHAR(20), value INT, boolval TINYINT, r8 DOUBLE, r4 FLOAT, d BLOB, ddd DECIMAL(10,2), u1 VARCHAR(10), u2 VARCHAR(10) );
+ENDEMBED;
+
+// Initialize the MySQL table, passing in the ECL dataset to provide the rows
+
+initialize(dataset(childrec) values) := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  INSERT INTO tbl1 values (?, ?, ?, ?, ?, ?, ?, ?, ?);
+ENDEMBED;
+
+// Add an additional row containing NULL values, to test that they are handled properly when read in ECL
+
+initializeNulls() := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  INSERT INTO tbl1 (name) values ('nulls');
+ENDEMBED;
+
+// Note that the query string is encoded in utf8
+
+initializeUtf8() := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  INSERT INTO tbl1 values ('utf8test', 1, 1, 1.2, 3.4, 'aa55aa55', 1234567.89, 'Straße', 'Straße');
+ENDEMBED;
+
+// Returning a dataset
+
+dataset(childrec) testMySQLDS() := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  SELECT * from tbl1;
+ENDEMBED;
+
+// Returning a single row
+
+childrec testMySQLRow() := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  SELECT * from tbl1 LIMIT 1;
+ENDEMBED;
+
+// Passing in parameters
+
+childrec testMySQLParms(
+
+   string name,
+   integer value,
+   boolean boolval,
+   real8 r8,
+   real4 r4,
+   DATA d,
+   UTF8 u1,
+   UNICODE8 u2) := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  SELECT * from tbl1 WHERE name=? AND value=? AND boolval=? AND r8=? AND r4=? AND d=? AND u1=? AND u2=?;
+ENDEMBED;
+
+// Returning scalars
+
+string testMySQLString() := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  SELECT max(name) from tbl1;
+ENDEMBED;
+
+dataset(childrec) testMySQLStringParam(string filter) := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  SELECT * from tbl1 where name = ?;
+ENDEMBED;
+
+integer testMySQLInt() := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  SELECT max(value) from tbl1;
+ENDEMBED;
+
+boolean testMySQLBool() := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  SELECT max(boolval) from tbl1;
+ENDEMBED;
+
+real8 testMySQLReal8() := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  SELECT max(r8) from tbl1;
+ENDEMBED;
+
+real4 testMySQLReal4() := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  SELECT max(r4) from tbl1;
+ENDEMBED;
+
+data testMySQLData() := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  SELECT max(d) from tbl1;
+ENDEMBED;
+
+UTF8 testMySQLUtf8() := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  SELECT max(u1) from tbl1;
+ENDEMBED;
+
+UNICODE testMySQLUnicode() := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  SELECT max(u2) from tbl1;
+ENDEMBED;
+
+// Passing in AND returning a dataset - this ends up acting a bit like a keyed join...
+
+stringrec := RECORD
+   string name
+END;
+
+stringrec extractName(childrec l) := TRANSFORM
+  SELF := l;
+END;
+
+dataset(childrec) testMySQLDSParam(dataset(stringrec) inrecs) := EMBED(mysql: user(dbUser), password(dbPassword), database(dbDatabase), server(dbServer), port(dbPort))
+  SELECT * from tbl1 where name = ?;
+ENDEMBED;
+
+sequential (
+  drop(),
+  create(),
+  initialize(init),
+  initializeNulls(),
+  initializeUtf8(),
+  OUTPUT(testMySQLDS()),
+  OUTPUT(testMySQLRow().name),
+  OUTPUT(testMySQLParms('name1', 1, true, 1.2, 3.4, D'aa55aa55', U'Straße', U'Straße')),
+  OUTPUT(testMySQLString()),
+  OUTPUT(testMySQLStringParam(testMySqlString())),
+  OUTPUT(testMySQLInt()),
+  OUTPUT(testMySQLBool()),
+  OUTPUT(testMySQLReal8()),
+  OUTPUT(testMySQLReal4()),
+  OUTPUT(testMySQLData()),
+  OUTPUT(testMySQLUtf8()),
+  OUTPUT(testMySQLUnicode()),
+  OUTPUT(testMySQLDSParam(PROJECT(init, extractName(LEFT))))
+);

--- a/bin/run_mysqlembed.sh
+++ b/bin/run_mysqlembed.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+WK_DIR=$(dirname $0)
+echo "Source MySQL environment"
+source /var/lib/HPCCSystems/charm/mysqlembed.cfg
+#cat /var/lib/HPCCSystems/charm/mysqlembed.cfg
+
+#echo "MYSQLDB_USER: $MYSQLDB_USER"
+#echo "MYSQLDB_SERVER: $MYSQLDB_HOST"
+
+
+echo "Compile ${WK_DIR}/my-simple-env.ecl"
+eclcc ${WK_DIR}/mysql-simple-env.ecl -o ${WK_DIR}/mysql-simple-env
+
+echo "Run my-simple-env"
+${WK_DIR}/mysql-simple-env

--- a/bin/test_mysql.sh
+++ b/bin/test_mysql.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+unit=hpcc/0
+[ -n "$1" ] && unit=$1
+
+echo "juju scp -- *mysql* ${unit}:/tmp/"
+juju scp -- *mysql* ${unit}:/tmp/
+
+echo "juju run --unit ${unit} sudo /tmp/run_mysqlembed.sh"
+juju run --unit ${unit} sudo /tmp/run_mysqlembed.sh

--- a/layers/layer-hpcc-platform/config.yaml
+++ b/layers/layer-hpcc-platform/config.yaml
@@ -2,7 +2,7 @@ options:
 
   platform-version:
     type: string
-    default: 7.2.20-1
+    default: 7.2.22-1
     description: HPCCSystems Platform  package version
 
   platform-type:
@@ -40,12 +40,12 @@ options:
            http://hpccsystems.com/download
       If the default value is empty string, checking is skipped.
 
-  javaembed-version:
+  mysqlembed-version:
     type: string
-    default: 7.2.8-1
-    description: HPCCSystems Javaembed Pluin package version
+    default: 7.2.22-1
+    description: HPCCSystems MySQLembed Pluin package version
 
-  javaembed-checksum:
+  mysqlembed-checksum:
     type: string
     default: ""
     description: checksum

--- a/layers/layer-hpcc-platform/dependencies/bionic/mysqlembed.yaml
+++ b/layers/layer-hpcc-platform/dependencies/bionic/mysqlembed.yaml
@@ -1,0 +1,2 @@
+packages:
+ - libmysqlclient20

--- a/layers/layer-hpcc-platform/layer.yaml
+++ b/layers/layer-hpcc-platform/layer.yaml
@@ -1,2 +1,3 @@
 includes:
   - 'layer:basic'
+  - 'interface:mysql'

--- a/layers/layer-hpcc-platform/metadata.yaml
+++ b/layers/layer-hpcc-platform/metadata.yaml
@@ -38,11 +38,11 @@ subordinate: false
 #    interface: tcp
 #    optional:  true
 
-#requires:
+requires:
 #   couchbase-embed:
 #     interface: couchbase 
 #     optional: true
 
-#   redis-embed:
-#     interface: redis 
-#     optional: true
+    mysql-db:
+      interface: mysql
+      optional: true

--- a/layers/layer-hpcc-platform/reactive/hpcc_platform.py
+++ b/layers/layer-hpcc-platform/reactive/hpcc_platform.py
@@ -108,11 +108,11 @@ def start_platform():
     remove_state('platform.start.failed')
     hpcc_init = HPCCInit()
     if hpcc_init.start():
-       set_state('platform.start.failed')
-       hookenv.status_set('blocked', 'hpcc start failed')
-    else:
        set_state('platform.started')
        hookenv.status_set('active', 'started')
+    else:
+       set_state('platform.start.failed')
+       hookenv.status_set('blocked', 'hpcc start failed')
 
 #@when('hpcc-esp.available')     
 #def configure_esp(http):

--- a/layers/layer-hpcc-platform/reactive/mysqldb.py
+++ b/layers/layer-hpcc-platform/reactive/mysqldb.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import os
+import platform
+import yaml
+import re
+#import Configparser
+from subprocess import check_call,check_output,CalledProcessError
+
+from charmhelpers import fetch
+#from charmhelpers.core import host
+from charmhelpers.core import hookenv
+from charmhelpers.core.hookenv import log
+# log level: CRITICAL,ERROR,WARNING,INFO,DEBUG
+from charmhelpers.core.hookenv import CRITICAL
+from charmhelpers.core.hookenv import ERROR
+from charmhelpers.core.hookenv import WARNING
+from charmhelpers.core.hookenv import INFO
+from charmhelpers.core.hookenv import DEBUG
+
+
+from charms.reactive.helpers import is_state
+from charms.reactive.bus import set_state
+from charms.reactive.bus import get_state
+from charms.reactive.bus import remove_state
+from charms.reactive import hook, when, when_not
+
+from charms.layer.hpcc_install import HPCCInstallation
+from charms.layer.hpcc_init import HPCCInit
+from charms.layer.hpcc_config import HPCCConfig
+from charms.layer.utils import SSHKey
+from charms.layer.hpccenv import HPCCEnv
+
+@when('mysql-db.available')
+@when_not('mysql-db.configured')
+def setup_mysqldb(mysql):
+
+    if not os.path.exists(HPCCEnv.JUJU_HPCC_DIR):
+              os.makedirs(HPCCEnv.JUJU_HPCC_DIR)
+    mysql_cfg_file = HPCCEnv.JUJU_HPCC_DIR + '/mysqlembed.cfg'
+    f = open(mysql_cfg_file, 'w')
+    f.write('export MYSQLDB_HOST=' + mysql.host() + '\n')
+    f.write('export MYSQLDB_DATABASE=' + mysql.database() + '\n')
+    f.write('export MYSQLDB_USER=' + mysql.user() + '\n')
+    f.write('export MYSQLDB_PASSWORD=' + mysql.password() + '\n')
+    f.close()
+    set_state('mysql-db.configured')


### PR DESCRIPTION
Usage:

Install mysqlembed to the nodes to compile and run mysql ecl:
In config.yaml:
    mysqlembed-version:
    type: string
    default: 7.2.22-1
    description: HPCCSystems MySQLembed Pluin package version

    mysqlembed-checksum:
       type: string
       default: ""
       description: checksum

Deploy mysql charm:
   juju deploy mysql mysql --series xenial

Add relation, for example if "hpcc" in the unit:
   juju add-relation hpcc mysql

To run the sample ECL code:
   Go to bin directory and run: ./test_mysql.sh